### PR TITLE
dcmio/dcmconverter/dicom_utils: can extract value from a sub-layer of…

### DIFF
--- a/dcmio/dcmconverter/dcm_to_nii_bbox.xml
+++ b/dcmio/dcmconverter/dcm_to_nii_bbox.xml
@@ -31,8 +31,8 @@
         <unit name="fill">
             <module>dcmio.dcmconverter.dicom_utils.add_meta_to_nii</module>
             <set name="prefix" value="'filled'"/>
-            <set name="dcm_tags" value="[('TR', ('0x0018', '0x0080')),
-                                         ('TE', ('0x0018', '0x0081'))]"/>
+            <set name="dcm_tags" value="[('TR', [('0x0018', '0x0080')]),
+                                         ('TE', [('0x0018', '0x0081')])]"/>
             <set name="output_directory" value="None"/>
             <set name="additional_information" value="[]"/>
         </unit>

--- a/dcmio/dcmconverter/dicom_utils.py
+++ b/dcmio/dcmconverter/dicom_utils.py
@@ -111,6 +111,9 @@ def add_meta_to_nii(nii_files, dicom_dir, prefix, dcm_tags, output_directory,
                     if len(tag) > 1:
                         for inner_tag in tag[:-1]:
                             seq_field = current_dataset[inner_tag]
+                            if not seq_field.VR == "SQ":
+                                raise Exception("the field {0} is not "
+                                                "a sequence".format(inner_tag))
                             current_dataset = seq_field.value[0]
                     last_tag = tag[-1]
                     content[str(name)] = str(current_dataset[last_tag].value)

--- a/dcmio/dcmconverter/dicom_utils.py
+++ b/dcmio/dcmconverter/dicom_utils.py
@@ -107,15 +107,16 @@ def add_meta_to_nii(nii_files, dicom_dir, prefix, dcm_tags, output_directory,
                 try:
                     # enhances storage, the value is burried under one or
                     # several layer(s) of sequence
-                    dcmimage_temp = dcmimage
+                    current_dataset = dcmimage
                     if len(tag) > 1:
-                        for sub_tag in tag[:-1]:
-                            seq_field = dcmimage_temp[sub_tag]
-                            dcmimage_temp = seq_field.value[0]
+                        for inner_tag in tag[:-1]:
+                            seq_field = current_dataset[inner_tag]
+                            current_dataset = seq_field.value[0]
                     last_tag = tag[-1]
-                    content[str(name)] = str(dcmimage_temp[last_tag].value)
+                    content[str(name)] = str(current_dataset[last_tag].value)
                 except:
                     pass
+
             # > add/update content
             for key, value in additional_information:
                 content[key] = value

--- a/dcmio/dcmreader/dcmreader.py
+++ b/dcmio/dcmreader/dcmreader.py
@@ -359,6 +359,28 @@ def get_manufacturer_name(path_to_dicom):
     return "unknown"
 
 
+def get_manufacturer_model_name(path_to_dicom):
+    """
+    Get sequence name as string
+
+    ..note: spaces are replaced by "_" in the extracted value
+
+    Parameters
+    ----------
+    inputs :
+        path_to_dicom: a filepath (mandatory) to the dicom from which the
+            data extraction will be made
+
+    Returns :
+        the manufacturer model name ('unknown' if the value is not found)
+    """
+    dataset = dicom.read_file(path_to_dicom, force=True)
+    value = walk(dataset, walker_callback, (0x0008, 0x1090))
+    if value:
+        return value.replace(" ", "_")
+    return "unknown"
+
+
 def get_sequence_name(path_to_dicom):
     """
     Get sequence name as string

--- a/dcmio/dcmreader/dcmreader.py
+++ b/dcmio/dcmreader/dcmreader.py
@@ -91,6 +91,28 @@ def walker_callback(data_element, _tag):
     return None
 
 
+def get_phase_encoding(path_to_dicom):
+    """
+        Get the phase encoding direction as string ("ROW" or "COL")
+
+    Parameters
+    ----------
+    inputs :
+        path_to_dicom: a filepath (mandatory) to the dicom from which the
+            data extraction will be made
+
+    Returns :
+        the phase encoding (none if not found)
+    """
+    dataset = dicom.read_file(path_to_dicom, force=True)
+    value = walk(dataset, walker_callback, (0x0018, 0x1312), stack_values=True)
+    if value:
+        return str(value[0])
+    elif value == []:
+        return None
+    return value
+
+
 def get_b_vectors(path_to_dicom):
     """
         Get the b-vectors as list of lists
@@ -102,7 +124,7 @@ def get_b_vectors(path_to_dicom):
             data extraction will be made
 
     Returns :
-        the b-vectors (empty list of not found)
+        the b-vectors (empty list if not found)
     """
     dataset = dicom.read_file(path_to_dicom, force=True)
     return walk(dataset, walker_callback, (0x0018, 0x9089), stack_values=True)
@@ -119,7 +141,7 @@ def get_b_values(path_to_dicom):
             data extraction will be made
 
     Returns :
-        the b-vectors (empty list of not found)
+        the b-vectors (empty list if not found)
     """
     dataset = dicom.read_file(path_to_dicom, force=True)
     return walk(dataset, walker_callback, (0x0018, 0x9087), stack_values=True)
@@ -313,6 +335,28 @@ def get_nb_temporal_position(path_to_dicom):
     if value:
         return int(value)
     return 0
+
+
+def get_manufacturer_name(path_to_dicom):
+    """
+    Get sequence name as string
+
+    ..note: spaces are replaced by "_" in the extracted value
+
+    Parameters
+    ----------
+    inputs :
+        path_to_dicom: a filepath (mandatory) to the dicom from which the
+            data extraction will be made
+
+    Returns :
+        the manufacturer name ('unknown' if the value is not found)
+    """
+    dataset = dicom.read_file(path_to_dicom, force=True)
+    value = walk(dataset, walker_callback, (0x0008, 0x0070))
+    if value:
+        return value.replace(" ", "_")
+    return "unknown"
 
 
 def get_sequence_name(path_to_dicom):

--- a/dcmio/test/test_dcm_to_nii.py
+++ b/dcmio/test/test_dcm_to_nii.py
@@ -88,8 +88,9 @@ def pilot_dcm2nii():
     pipeline.additional_informations = [[("Provided by", "Neurospin@2015")],
                                         [("Provided by", "Neurospin@2015"),
                                          ("TR", "1500")]]
-    pipeline.dcm_tags = [("TR", ("0x0018", "0x0080")),
-                         ("TE", ("0x0018", "0x0081"))]
+
+    pipeline.dcm_tags = [("TR", [("0x0018", "0x0080")]),
+                         ("TE", [("0x0018", "0x0081")])]
 
     """
     Pipeline representation


### PR DESCRIPTION
… the dicom. Used for enhanced storage format.

Adding a try/except identation in case the field is missing.
